### PR TITLE
Split extended names like `User.entity` to `User`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,11 @@ export function load(app: Readonly<Application>) {
       // Removes the folder name
       const name = reflection.parent.name.split("/").pop();
       if (name) {
-        reflection.name = name;
+        if (name.includes(".")) {
+          reflection.name = name.split(".")[0];
+        } else {
+          reflection.name = name;
+        }
       }
     }
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,8 @@ export function load(app: Readonly<Application>) {
       // Removes the folder name
       const name = reflection.parent.name.split("/").pop();
       if (name) {
-        if (name.includes(".")) {
-          reflection.name = name.split(".")[0];
-        } else {
-          reflection.name = name;
-        }
+        // Example: User.entity becomes just User
+        reflection.name = name.split(".")[0];
       }
     }
   );

--- a/test/test5.test.ts
+++ b/test/test5.test.ts
@@ -1,0 +1,3 @@
+export default (param: string) => {
+  return;
+};


### PR DESCRIPTION
Sometime people write file names with some reference. For example I usually write file like `User.entity.ts` `User.repo.ts` 
Files that are related to `Entity` I write `entity.ts` like that But Class Names are Like `User` So I want in docs class Name should show like `User` not `User.entity`