### PR TITLE
Retain dots from the module name

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,9 @@ export function load(app) {
     // Finally, fallback to the file name
     if (reflection.parent && reflection.parent.name) {
       // Removes the folder name
-      const name = reflection.parent.name.split("/").pop();
+      const name = reflection.parent.getFriendlyFullName().split("/").pop();
       if (name) {
-        // Example: User.entity becomes just User
-        reflection.name = name.split(".")[0];
+        reflection.name = name;
       }
     }
   }

--- a/test/test9.ts
+++ b/test/test9.ts
@@ -1,0 +1,2 @@
+/** @module test9.hi.hi.hi */
+export default "hihihihi"


### PR DESCRIPTION
<table><td>

before<br>
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/edf23de1-7c91-427e-aa93-cab074eb1431)

<td>

after<br>
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/66b410a0-6f5b-4c32-9d36-b3e92f48917b)

</table>

honestly im not entirely sure of the difference between .name and .getFriendlyFullName(). it appears as though .getFriendlyFullName() is a wrapper around .name with some magic? do you want the magic frm getFriendlyFullName() too or no? idk which is better 🤷‍♂️

<details><summary>code from typedoc in my node_modules for the getFriendlyFullName() func</summary>

```js
/**
     * Return the full name of this reflection, with signature names dropped if possible without
     * introducing ambiguity in the name.
     */
    getFriendlyFullName() {
        if (this.parent && !this.parent.isProject()) {
            if (this.kindOf(kind_1.ReflectionKind.ConstructorSignature |
                kind_1.ReflectionKind.CallSignature |
                kind_1.ReflectionKind.GetSignature |
                kind_1.ReflectionKind.SetSignature)) {
                return this.parent.getFriendlyFullName();
            }
            return this.parent.getFriendlyFullName() + "." + this.name;
        }
        else {
            return this.name;
        }
    }
```

</details>

use case that prompted this: investigating using TypeDoc for https://github.com/zloirock/core-js with module names like array.at or object.assign or similar. those got mangled due to the `.split(".")` stuff

https://github.com/felipecrs/typedoc-plugin-rename-defaults/blob/b34891030e6ba1e3e545672469d374299e35a717/index.js#L43

<table><td>

before<br>
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/5523c646-00ac-46a8-974f-e1c4175a248a)

<td>

after<br>
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/96d9b400-c47c-48b2-ae2a-82bb9b1a8053)

</table>

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github/jcbhmr/typedoc-plugin-rename-defaults/tree/jcbhmr%2Fpatch-85337"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/jcbhmr/typedoc-plugin-rename-defaults/tree/jcbhmr%2Fpatch-85337)._