### PR TITLE
show module index immediately on dev

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,6 +3,7 @@
   "typedocOptions": {
     "entryPointStrategy": "expand",
     "entryPoints": ["."],
+    "readme": "none",
     "plugin": ["../index.js"]
   }
 }


### PR DESCRIPTION
this was something that i found mildly annoying when using https://pr.new to make the other pr #11. due to the preview pane being phone-like, typedoc auto-hides the index on the readme page lol

<table><td>

before<br>
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/6a7eb4e7-65cf-4f59-8f12-2f7b5ad1dddc)

<td>

after<br>
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/79d2747f-4e71-4f8e-9b6a-58d477d49015)

</table>

while on the topic of defaults, funny story: i was scratching my head wondering if my fork was broken since stackblitz couldn't find the upstream primary branch to open a #11  against haha. turns out it was because it expected the default branch to be called "main" not "master" 🤣

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github/jcbhmr/typedoc-plugin-rename-defaults/tree/jcbhmr%2Fpatch-85337"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/jcbhmr/typedoc-plugin-rename-defaults/tree/jcbhmr%2Fpatch-39004)._