### PR TITLE
use the @ name jsdoc tag if present

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,10 @@ export function load(app) {
     const symbol = context.project.getSymbolFromReflection(reflection);
     
     // First thing: if there's a JSDoc /** @name myVarName */ tag, use the first one.
-    console.debug(symbol.getJsDocTags())
+    // console.debug(symbol.getJsDocTags())
     const nameTag = symbol.getJsDocTags().find(x => x.name === "name")
     if (nameTag?.text) {
-      console.debug(nameTag)
+      // console.debug(nameTag)
       // Use the first value. No idea what the rest are.
       reflection.name = nameTag.text[0].text
       return

--- a/index.js
+++ b/index.js
@@ -13,6 +13,14 @@ export function load(app) {
       return;
     }
 
+    // First check if there's a JSDoc /** @name myVarName */ tag. If so, use the
+    // first one. There CAN be more than one.
+    const nameTag = symbol.getJsDocTags().find(x => x.name === "name")
+    if (nameTag?.text) {
+      reflection.name = nameTag.text[0].text
+      return
+    }
+
     // reflection.escapedName is the cheapest option
     if (
       reflection.escapedName &&
@@ -32,11 +40,6 @@ export function load(app) {
         reflection.name = node.name.getText();
         return;
       }
-    }
-    const nameTag = symbol.getJsDocTags().find(x => x.name === "name")
-    if (nameTag?.text) {
-      reflection.name = nameTag.text[0].text
-      return
     }
 
     // Finally, fallback to the file name

--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ export function load(app) {
         return;
       }
     }
+    const nameTag = symbol.getJsDocTags().find(x => x.name === "name")
+    if (nameTag?.text) {
+      reflection.name = nameTag.text[0].text
+      return
+    }
 
     // Finally, fallback to the file name
     if (reflection.parent && reflection.parent.name) {

--- a/index.js
+++ b/index.js
@@ -13,10 +13,14 @@ export function load(app) {
       return;
     }
 
-    // First check if there's a JSDoc /** @name myVarName */ tag. If so, use the
-    // first one. There CAN be more than one.
+    const symbol = context.project.getSymbolFromReflection(reflection);
+    
+    // First thing: if there's a JSDoc /** @name myVarName */ tag, use the first one.
+    console.debug(symbol.getJsDocTags())
     const nameTag = symbol.getJsDocTags().find(x => x.name === "name")
     if (nameTag?.text) {
+      console.debug(nameTag)
+      // Use the first value. No idea what the rest are.
       reflection.name = nameTag.text[0].text
       return
     }
@@ -32,7 +36,6 @@ export function load(app) {
     }
 
     // if that does not work, try harder
-    const symbol = context.project.getSymbolFromReflection(reflection);
     if (symbol && symbol.declarations && symbol.declarations[0]) {
       /** @type {any} */
       const node = symbol.declarations[0];

--- a/test/test10.ts
+++ b/test/test10.ts
@@ -1,0 +1,2 @@
+/** @name WOWOWOWWOW_lookatme */
+export default "hello"

--- a/test/test10.ts
+++ b/test/test10.ts
@@ -1,2 +1,11 @@
-/** @name WOWOWOWWOW_lookatme */
-export default "hello"
+/**
+ * @name WOWOWOWWOW_lookatme-and.dashes$and#dotstoo!
+ * @name multipleNames-means-pick-the-FIRSTONE
+ */
+const helloWorld = 45;
+
+/**
+ * @name anothersillyname
+ * @name thisNameWontBeUsed
+ */
+export default helloWorld

--- a/test/test11.ts
+++ b/test/test11.ts
@@ -1,0 +1,5 @@
+/**
+ * @name thistime_the(namehere)^willbeused
+ * @name sinceitsinline!
+ */
+export default "hello world"


### PR DESCRIPTION
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/8c0341df-6af1-4894-8900-f2aa9204c346)
👇
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/73d3bc1d-5510-4d6f-8f00-29b9d9cd6112)

and another:

![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/bc09672d-f746-48d0-8d26-bb39f43c5410)
👇
![image](https://github.com/felipecrs/typedoc-plugin-rename-defaults/assets/61068799/4a04f52f-f1a4-4ef0-8e06-cf657b6e332c)

---

uses that `@name mynamehere` tag if available.

 i put this condition BEFORE the reflection.escapedName one that would use the `helloWorld` var name and return. idk if this was a good idea or not. 🤷‍♂️

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github/jcbhmr/typedoc-plugin-rename-defaults/tree/jcbhmr%2Fpatch-55042"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/jcbhmr/typedoc-plugin-rename-defaults/tree/jcbhmr%2Fpatch-55042)._