### PR TITLE
Breaking change: retain all parts of module name and make it camelCase

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import { Converter } from "typedoc";
+import camelCase from 'camelcase';
 
 /**
  * @param {Readonly<import('typedoc').Application>} app
@@ -34,11 +35,16 @@ export function load(app) {
       }
     }
 
-    // Finally, fallback to the file name
+    // Finally, fallback to the camel cased module (file) name
     if (reflection.parent && reflection.parent.name) {
-      // Removes the folder name
-      const name = reflection.parent.getFriendlyFullName().split("/").pop();
+      let name = reflection.parent.getFriendlyFullName()
       if (name) {
+        // Removes the folder name if there is any
+        name = name.split("/").pop();
+
+        // Camel cases the name
+        name = camelCase(name, {preserveConsecutiveUppercase: true})
+
         reflection.name = name;
       }
     }

--- a/index.js
+++ b/index.js
@@ -37,10 +37,9 @@ export function load(app) {
     // Finally, fallback to the file name
     if (reflection.parent && reflection.parent.name) {
       // Removes the folder name
-      const name = reflection.parent.name.split("/").pop();
+      const name = reflection.parent.getFriendlyFullName().split("/").pop();
       if (name) {
-        // Example: User.entity becomes just User
-        reflection.name = name.split(".")[0];
+        reflection.name = name;
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { Converter } from "typedoc";
-import camelCase from 'camelcase';
+import camelCase from "camelcase";
 
 /**
  * @param {Readonly<import('typedoc').Application>} app
@@ -37,13 +37,12 @@ export function load(app) {
 
     // Finally, fallback to the camel cased module (file) name
     if (reflection.parent && reflection.parent.name) {
-      let name = reflection.parent.getFriendlyFullName()
+      let name = reflection.parent.getFriendlyFullName();
       if (name) {
-        // Removes the folder name if there is any
+        // Remove the folder name if there is any
         name = name.split("/").pop();
 
-        // Camel cases the name
-        name = camelCase(name, {preserveConsecutiveUppercase: true})
+        name = camelCase(name, { preserveConsecutiveUppercase: true });
 
         reflection.name = name;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "typedoc-plugin-rename-defaults",
       "version": "0.6.7",
       "license": "MIT",
+      "dependencies": {
+        "camelcase": "^8.0.0"
+      },
       "devDependencies": {
         "serve": "^14.2.1",
         "typedoc": "^0.25.2",
@@ -186,6 +189,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -206,12 +221,11 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-      "dev": true,
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "volta": {
     "node": "18.18.2",
     "npm": "10.2.1"
+  },
+  "dependencies": {
+    "camelcase": "^8.0.0"
   }
 }

--- a/test/test9.ts
+++ b/test/test9.ts
@@ -1,0 +1,2 @@
+/** @module test9.hi.hi.hi */
+export default "hihihihi"

--- a/test/test9.ts
+++ b/test/test9.ts
@@ -1,2 +1,4 @@
-/** @module test9.hi.hi.hi */
-export default "hihihihi"
+/**
+ * @module test9.TEST.test
+ */
+export default "some text"


### PR DESCRIPTION
This is a breaking change, previously, module names like _User.entity.ts_ would get docs generated as _User_ as we would drop everything after the first dot. Now, we will use the full name of the module but _camelCased_. For the example above, the name in the docs would be generated as _UserEntity_.

Please let me know if you would prefer the previous behavior.

- Builds on #11
- Closes #14